### PR TITLE
ServiceクラスでfindByMovieIdの単体テスト

### DIFF
--- a/src/main/java/movieinformation/Form/MovieRegistrationForm.java
+++ b/src/main/java/movieinformation/Form/MovieRegistrationForm.java
@@ -7,7 +7,6 @@ import java.time.LocalDate;
 import java.sql.Date;
 
 public class MovieRegistrationForm {
-    private int id;
     @NotEmpty //文字列やコレクションなどの文字列が空でないことを検証
     private String name;
     @NotNull //空（null）であるかどうかを検証
@@ -17,8 +16,7 @@ public class MovieRegistrationForm {
     @PositiveOrZero //数値が正か 0 であることを検証
     private long boxOffice;
 
-    public MovieRegistrationForm(int id, String name, LocalDate releaseDate, String directorName, long boxOffice) {
-        this.id = id;
+    public MovieRegistrationForm(String name, LocalDate releaseDate, String directorName, long boxOffice) {
         this.name = name;
         this.releaseDate = releaseDate;
         this.directorName = directorName;
@@ -26,12 +24,8 @@ public class MovieRegistrationForm {
     }
 
     public Movie convertToMovie() {
-        Movie movie = new Movie(this.id, this.name, this.releaseDate, this.directorName, this.boxOffice);
+        Movie movie = new Movie(this.name, this.releaseDate, this.directorName, this.boxOffice);
         return movie;
-    }
-
-    public int getId() {
-        return id;
     }
 
     public String getName() {

--- a/src/main/java/movieinformation/entity/Movie.java
+++ b/src/main/java/movieinformation/entity/Movie.java
@@ -12,8 +12,7 @@ public class Movie {
     private long boxOffice;
 
     //MovieRegistrationFormのconvertToMovie()
-    public Movie(Object object, String name, LocalDate releaseDate, String directorName, long boxOffice) {
-        this.id = id;
+    public Movie(String name, LocalDate releaseDate, String directorName, long boxOffice) {
         this.name = name;
         this.releaseDate = releaseDate;
         this.directorName = directorName;

--- a/src/main/java/movieinformation/entity/Movie.java
+++ b/src/main/java/movieinformation/entity/Movie.java
@@ -2,6 +2,7 @@ package movieinformation.entity;
 
 import java.time.LocalDate;
 import java.sql.Date;
+import java.util.Objects;
 
 public class Movie {
     private int id;
@@ -47,4 +48,20 @@ public class Movie {
     public long getBoxOffice() {
         return boxOffice;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Movie movie = (Movie) o;
+        return id == movie.id && Objects.equals(name, movie.name) && Objects.equals(releaseDate, movie.releaseDate) && Objects.equals(directorName, movie.directorName) && Objects.equals(boxOffice, movie.boxOffice);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, releaseDate, directorName, boxOffice);
+    }
 }
+

--- a/src/main/java/movieinformation/service/MovieInformationService.java
+++ b/src/main/java/movieinformation/service/MovieInformationService.java
@@ -33,7 +33,6 @@ public class MovieInformationService {
         if (movieInformationMapper.findMovie(movie.getName()).isPresent()) {
             throw new MovieDuplicationException("Already registered data");
         } else {
-            //Movie movie = new Movie(null, name, releaseDate, directorName, boxOffice);
             movieInformationMapper.insertMovie(movie);
             return movie;
         }

--- a/src/test/java/movieinformation/service/MovieInformationServiceTest.java
+++ b/src/test/java/movieinformation/service/MovieInformationServiceTest.java
@@ -1,0 +1,39 @@
+package movieinformation.service;
+
+import movieinformation.Exception.MovieInformationNotFoundException;
+import movieinformation.entity.Movie;
+import movieinformation.mapper.MovieInformationMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MovieInformationServiceTest {
+
+    @InjectMocks
+    MovieInformationService movieInformationService;
+
+    @Mock
+    MovieInformationMapper movieInformationMapper;
+
+    @Test
+    public void 存在する映画のIDを指定したときに正常に映画が返されること() throws
+            MovieInformationNotFoundException {
+        doReturn(Optional.of(new Movie(1, "Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007)))
+                .when(movieInformationMapper).findByMovieId(1);
+
+        Movie actual = movieInformationService.findByMovieId(1);
+        assertThat(actual).isEqualTo(new Movie(1, "Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007));
+
+    }
+}

--- a/src/test/java/movieinformation/service/MovieInformationServiceTest.java
+++ b/src/test/java/movieinformation/service/MovieInformationServiceTest.java
@@ -14,8 +14,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MovieInformationServiceTest {
@@ -26,14 +25,22 @@ class MovieInformationServiceTest {
     @Mock
     MovieInformationMapper movieInformationMapper;
 
+    //GETのテストコード
     @Test
     public void 存在する映画のIDを指定したときに正常に映画が返されること() throws
             MovieInformationNotFoundException {
         doReturn(Optional.of(new Movie(1, "Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007)))
                 .when(movieInformationMapper).findByMovieId(1);
-
         Movie actual = movieInformationService.findByMovieId(1);
         assertThat(actual).isEqualTo(new Movie(1, "Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007));
+    }
 
+    @Test
+    public void 存在しない映画のIDを指定したときに例外処理が動作すること() throws
+            MovieInformationNotFoundException {
+        doThrow(new MovieInformationNotFoundException("movie information not found")).when(movieInformationMapper).findByMovieId(100);
+        assertThrows(MovieInformationNotFoundException.class, () -> {
+            movieInformationService.findByMovieId(100);
+        });
     }
 }


### PR DESCRIPTION
## 対応中
serviceの単体テスト（Read）を実装

## 詰まっている部分
テストを実行した場合は下記のようなエラーが返ってきている状況です。
Movieクラスのエンティティに格納される値が異なるということが理解できましたが
そこからどのように修正すればいいのか詰まっています。

```
Expected :movieinformation.entity.Movie@4930539b
Actual   :movieinformation.entity.Movie@258ee7de
```

IntelliJのスクリーンショット
<img width="1680" alt="スクリーンショット 2023-10-28 15 05 01" src="https://github.com/yamahiro20639/Assignment10/assets/144509349/d199e0ec-daa3-45f4-8f7c-2fa387bb901b">

## 試してみたこと
デバックでコードの動きを確認
他の受講生さんのコードチェック
