### PR TITLE
Serviceクラスでinsert処理のテスト実装

### DIFF
--- a/src/test/java/movieinformation/service/MovieInformationServiceTest.java
+++ b/src/test/java/movieinformation/service/MovieInformationServiceTest.java
@@ -1,5 +1,6 @@
 package movieinformation.service;
 
+import movieinformation.Exception.MovieDuplicationException;
 import movieinformation.Exception.MovieInformationNotFoundException;
 import movieinformation.entity.Movie;
 import movieinformation.mapper.MovieInformationMapper;
@@ -74,5 +75,12 @@ class MovieInformationServiceTest {
         doNothing().when(movieInformationMapper).insertMovie(movie);
         Movie actual = movieInformationService.insertMovie(movie);
         assertThat(actual).isEqualTo(new Movie("Marvel's The Avengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988));
+    }
+
+    @Test
+    public void 存在する映画情報を新規登録する場合に重複登録の例外処理が動作すること() throws MovieDuplicationException {
+        Movie movie = new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007);
+        doThrow(new MovieDuplicationException("Already registered data")).when(movieInformationMapper).insertMovie(movie);
+        assertThrows(MovieDuplicationException.class, () -> movieInformationService.insertMovie(new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007)));
     }
 }

--- a/src/test/java/movieinformation/service/MovieInformationServiceTest.java
+++ b/src/test/java/movieinformation/service/MovieInformationServiceTest.java
@@ -1,6 +1,5 @@
 package movieinformation.service;
 
-import movieinformation.Exception.MovieDuplicationException;
 import movieinformation.Exception.MovieInformationNotFoundException;
 import movieinformation.entity.Movie;
 import movieinformation.mapper.MovieInformationMapper;
@@ -72,9 +71,8 @@ class MovieInformationServiceTest {
     @Test
     public void 存在しない映画情報を新規登録すること() {
         Movie movie = new Movie("Marvel's The Avengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988);
-        when(movieInformationMapper.insertMovie(movie))
-                .thenReturn(new Movie(30, "Marvel's The Avengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988));
+        doNothing().when(movieInformationMapper).insertMovie(movie);
         Movie actual = movieInformationService.insertMovie(movie);
-        assertThat(actual).isEqualTo(new Movie(30, "Marvel's The Avengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988));
+        assertThat(actual).isEqualTo(new Movie("Marvel's The Avengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988));
     }
 }

--- a/src/test/java/movieinformation/service/MovieInformationServiceTest.java
+++ b/src/test/java/movieinformation/service/MovieInformationServiceTest.java
@@ -1,5 +1,6 @@
 package movieinformation.service;
 
+import movieinformation.Exception.MovieDuplicationException;
 import movieinformation.Exception.MovieInformationNotFoundException;
 import movieinformation.entity.Movie;
 import movieinformation.mapper.MovieInformationMapper;
@@ -65,5 +66,15 @@ class MovieInformationServiceTest {
         assertThrows(MovieInformationNotFoundException.class, () -> {
             movieInformationService.findByMovieId(100);
         });
+    }
+
+    //POSTのテストコード
+    @Test
+    public void 存在しない映画情報を新規登録すること() {
+        Movie movie = new Movie("Marvel's The Avengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988);
+        when(movieInformationMapper.insertMovie(movie))
+                .thenReturn(new Movie(30, "Marvel's The Avengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988));
+        Movie actual = movieInformationService.insertMovie(movie);
+        assertThat(actual).isEqualTo(new Movie(30, "Marvel's The Avengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988));
     }
 }


### PR DESCRIPTION
## 現状
存在しない映画情報を新規登録する処理(POST)で、Serviceクラスのinsert処理に対してテストを行っています。
しかし、doReturnメソッドを活用したところ、下記のようなエラーメッセージが返ってきました。

要因を調べましたが、voidのメソッドのMockにdoReturn()で戻り値を設定できないと知りました。
一方、when().thenReturn()でも表現できるのではないかと思い試してみましたが、赤い波線が消えず困っている状況です。(スクリーンショット)
```
org.mockito.exceptions.misusing.CannotStubVoidMethodWithReturnValue: 
'insertMovie' is a *void method* and it *cannot* be stubbed with a *return value*!
Voids are usually stubbed with Throwables:
```

## 質問
'insertMovie' is a *void method* and it *cannot* be stubbed with a *return value*!
に対して、when().thenReturn()を使うのは適切でしょうか？

また赤い波線を解消するためにどこが間違っているかヒントいただきますと幸甚です。

<img width="1417" alt="スクリーンショット 2023-10-30 20 48 38" src="https://github.com/yamahiro20639/Assignment10/assets/144509349/9d3fef1b-6904-4552-b922-48fe272a4b64">

