### PR TITLE
ServiceクラスでUpdate処理の単体テスト

### DIFF
--- a/src/test/java/movieinformation/service/MovieInformationServiceTest.java
+++ b/src/test/java/movieinformation/service/MovieInformationServiceTest.java
@@ -2,8 +2,10 @@ package movieinformation.service;
 
 import movieinformation.Exception.MovieDuplicationException;
 import movieinformation.Exception.MovieInformationNotFoundException;
+import movieinformation.Exception.MovieNotFoundException;
 import movieinformation.entity.Movie;
 import movieinformation.mapper.MovieInformationMapper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -82,5 +84,14 @@ class MovieInformationServiceTest {
         Movie movie = new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007);
         doThrow(new MovieDuplicationException("Already registered data")).when(movieInformationMapper).insertMovie(movie);
         assertThrows(MovieDuplicationException.class, () -> movieInformationService.insertMovie(new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007)));
+    }
+
+    //PATCHのテストコード
+    @Test
+    public void 存在する映画の情報を更新すること() {
+        doNothing().when(movieInformationMapper).updateMovie(new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007));
+        Movie actual = movieInformationService.updateMovie(new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007));
+        assertThat(actual).isEqualTo(new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007));
+
     }
 }

--- a/src/test/java/movieinformation/service/MovieInformationServiceTest.java
+++ b/src/test/java/movieinformation/service/MovieInformationServiceTest.java
@@ -5,7 +5,6 @@ import movieinformation.Exception.MovieInformationNotFoundException;
 import movieinformation.Exception.MovieNotFoundException;
 import movieinformation.entity.Movie;
 import movieinformation.mapper.MovieInformationMapper;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/src/test/java/movieinformation/service/MovieInformationServiceTest.java
+++ b/src/test/java/movieinformation/service/MovieInformationServiceTest.java
@@ -88,13 +88,19 @@ class MovieInformationServiceTest {
 
     //PATCHのテストコード
     @Test
-    public void 存在する映画の情報を更新すること() {
+    public void 存在する映画IDの情報を更新すること() {
         Movie movie = new Movie(1, "Episode IV – A New Hope", LocalDate.of(1997, 6, 30), "George Walton Lucas Jr.", 775398007);
         doReturn(Optional.of(movie.getId()))
                 .when(movieInformationMapper).findMovieId(1);
         doNothing().when(movieInformationMapper).updateMovie(new Movie(1, "Big Hero 6", LocalDate.of(2014, 12, 20), "Chris Williams", 657827828));
         Movie actual = movieInformationService.updateMovie(new Movie(1, "Big Hero 6", LocalDate.of(2014, 12, 20), "Chris Williams", 657827828));
         assertThat(actual).isEqualTo(new Movie(1, "Big Hero 6", LocalDate.of(2014, 12, 20), "Chris Williams", 657827828));
+    }
+
+    @Test
+    public void 存在しない映画IDの情報を更新する場合の例外処理() throws MovieNotFoundException {
+        doThrow(new MovieNotFoundException("Movie not found")).when(movieInformationMapper).findMovieId(100);
+        assertThrows(MovieNotFoundException.class, () -> movieInformationService.updateMovie(new Movie(100, "Big Hero 6", LocalDate.of(2014, 12, 20), "Chris Williams", 657827828)));
     }
 
 }

--- a/src/test/java/movieinformation/service/MovieInformationServiceTest.java
+++ b/src/test/java/movieinformation/service/MovieInformationServiceTest.java
@@ -89,9 +89,12 @@ class MovieInformationServiceTest {
     //PATCHのテストコード
     @Test
     public void 存在する映画の情報を更新すること() {
-        doNothing().when(movieInformationMapper).updateMovie(new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007));
-        Movie actual = movieInformationService.updateMovie(new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007));
-        assertThat(actual).isEqualTo(new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007));
-
+        Movie movie = new Movie(1, "Episode IV – A New Hope", LocalDate.of(1997, 6, 30), "George Walton Lucas Jr.", 775398007);
+        doReturn(Optional.of(movie.getId()))
+                .when(movieInformationMapper).findMovieId(1);
+        doNothing().when(movieInformationMapper).updateMovie(new Movie(1, "Big Hero 6", LocalDate.of(2014, 12, 20), "Chris Williams", 657827828));
+        Movie actual = movieInformationService.updateMovie(new Movie(1, "Big Hero 6", LocalDate.of(2014, 12, 20), "Chris Williams", 657827828));
+        assertThat(actual).isEqualTo(new Movie(1, "Big Hero 6", LocalDate.of(2014, 12, 20), "Chris Williams", 657827828));
     }
+
 }


### PR DESCRIPTION
## 対応中
Serviceクラスでデータベースに存在する映画情報の更新処理について単体テストを作成中です。
ただうまくテストが通らず、相談させていただきました。

## 現状
テストコードを記述して、動作確認したところ、`movieinformation.Exception.MovieNotFoundException: Movie not found`でエラーメッセージが返ってきました。
内容からして更新するための映画情報が存在しないということではないかと推測しました。
そこで更新する映画情報を仮で設定したいのですが、実装方法が検討ついていません。
お手数ですが、解決にあたってのヒントやご助言をいただきますと幸いです。
<img width="1680" alt="スクリーンショット 2023-11-01 6 59 56" src="https://github.com/yamahiro20639/Movie-Information-Management-API/assets/144509349/7c4c71bb-76d4-48ed-9722-7a6e84f104cc">

## 試したこと
@Beforeのアノテーションを実施
上記のアノテーションを付与したメソッドは、テストメソッドが実行される前に動作すると学びました。そこでMapperに付与してみました。
→しかし、うまく動作せず。

他の受講生さんのコード確認
