### PR TITLE
GitHub ActionsのCIとCodecovを追加

### DIFF
--- a/.github/workflows/MovieInformationTest.yml
+++ b/.github/workflows/MovieInformationTest.yml
@@ -58,7 +58,7 @@ jobs:
 
       # Discord に通知を送信するためのアクション
       - name: Discord Notification
-          uses: "sarisia/actions-status-discord@v1"
+          uses: sarisia/actions-status-discord@v1
           if: always()
           with:
             webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/MovieInformationTest.yml
+++ b/.github/workflows/MovieInformationTest.yml
@@ -63,9 +63,8 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
-          title: "Continuous Integration"　
+          title: "Continuous Integration"
           description: "Run Continuous Integration"
           color: "#88d297"
           url: "https://github.com/sarisia/actions-status-discord"
           username: GitHub Actions
-

--- a/.github/workflows/MovieInformationTest.yml
+++ b/.github/workflows/MovieInformationTest.yml
@@ -61,11 +61,11 @@ jobs:
         uses: sarisia/actions-status-discord@v1
         if: always()
         with:
-            webhook: ${{ secrets.DISCORD_WEBHOOK }}
-            status: ${{ job.status }}
-            title: "Continuous Integration"　
-            description: "Run Continuous Integration"
-            color: "#88d297"
-            url: "https://github.com/sarisia/actions-status-discord"
-            username: GitHub Actions
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: ${{ job.status }}
+          title: "Continuous Integration"　
+          description: "Run Continuous Integration"
+          color: "#88d297"
+          url: "https://github.com/sarisia/actions-status-discord"
+          username: GitHub Actions
 

--- a/.github/workflows/MovieInformationTest.yml
+++ b/.github/workflows/MovieInformationTest.yml
@@ -1,27 +1,27 @@
 name: movieInformation-CI
 
-#push実行時にワークフローが作動
+# push実行時にワークフローが作動
 on:
   pull_request:
 
-#コンテンツの読み取りとチェックの書き込み権限が指定
+# コンテンツの読み取りとチェックの書き込み権限が指定
 permissions:
   contents: read
   checks: write
 
-#ワークフローが実行するジョブ（Job）の定義を開始 jobsの名前は「build」
+# ワークフローが実行するジョブ（Job）の定義を開始 jobsの名前は「build」
 jobs:
   build:
-    runs-on: ubuntu-latest　 #ジョブを実行するOS(ランナー)を指定,今回はGitHubが提供するUbuntuの最新バージョン
+    runs-on: ubuntu-latest # ジョブを実行するOS(ランナー)を指定,今回はGitHubが提供するUbuntuの最新バージョン
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      #Dockerコンテナをバックグラウンドで起動
+      # Dockerコンテナをバックグラウンドで起動
       - name: Run Docker
         run: docker compose up -d
 
-      #AdoptOpenJDKからJDK 17を取得
+      # AdoptOpenJDKからJDK 17を取得
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -31,7 +31,7 @@ jobs:
       - name: Conduct Tests
         run: ./gradlew test --info
 
-      #テスト結果のレポートを生成し、それを適切な形式で GitHub 上に公開する
+      # テスト結果のレポートを生成し、それを適切な形式で GitHub 上に公開する
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always()

--- a/.github/workflows/MovieInformationTest.yml
+++ b/.github/workflows/MovieInformationTest.yml
@@ -1,7 +1,8 @@
 name: movieInformation-CI
 
 #push実行時にワークフローが作動
-on: [push]
+on:
+  pull_request:
 
 #コンテンツの読み取りとチェックの書き込み権限が指定
 permissions:

--- a/.github/workflows/MovieInformationTest.yml
+++ b/.github/workflows/MovieInformationTest.yml
@@ -58,9 +58,9 @@ jobs:
 
       # Discord に通知を送信するためのアクション
       - name: Discord Notification
-          uses: sarisia/actions-status-discord@v1
-          if: always()
-          with:
+        uses: sarisia/actions-status-discord@v1
+        if: always()
+        with:
             webhook: ${{ secrets.DISCORD_WEBHOOK }}
             status: ${{ job.status }}
             title: "Continuous Integration"　

--- a/.gradle/workflows/MovieInformationTest.yml
+++ b/.gradle/workflows/MovieInformationTest.yml
@@ -1,7 +1,10 @@
 name: movieInformation-CI
 
 #プルリクエスト実行時にワークフローが作動
-on: [ pull_request ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
 
 #コンテンツの読み取りとチェックの書き込み権限が指定
 permissions:

--- a/.gradle/workflows/MovieInformationTest.yml
+++ b/.gradle/workflows/MovieInformationTest.yml
@@ -1,9 +1,7 @@
 name: movieInformation-CI
 
-#プルリクエスト実行時にワークフローが作動
-on:
-  push:
-  pull_request:
+#push実行時にワークフローが作動
+on: [push]
 
 #コンテンツの読み取りとチェックの書き込み権限が指定
 permissions:

--- a/.gradle/workflows/MovieInformationTest.yml
+++ b/.gradle/workflows/MovieInformationTest.yml
@@ -1,0 +1,70 @@
+name: movieInformation-CI
+
+#プルリクエスト実行時にワークフローが作動
+on: [ pull_request ]
+
+#コンテンツの読み取りとチェックの書き込み権限が指定
+permissions:
+  contents: read
+  checks: write
+
+#ワークフローが実行するジョブ（Job）の定義を開始 jobsの名前は「build」
+jobs:
+  build:
+    runs-on: ubuntu-latest　 #ジョブを実行するOS(ランナー)を指定,今回はGitHubが提供するUbuntuの最新バージョン
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      #Dockerコンテナをバックグラウンドで起動
+      - name: Run Docker
+        run: docker compose up -d
+
+      #AdoptOpenJDKからJDK 17を取得
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Conduct Tests
+        run: ./gradlew test --info
+
+      #テスト結果のレポートを生成し、それを適切な形式で GitHub 上に公開する
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+      # Checkstyle を実行してコードのスタイルや品質に関する問題を検出し、それを GitHub 上で表示可能な形式に変換するためのもの
+      - name: Run Checkstyle
+        uses: nikitasavinov/checkstyle-action@master
+        if: always()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: 'github-pr-check'
+          tool_name: 'reviewdog'
+          checkstyle_config: 'config/checkstyle/checkstyle.xml'
+          workdir: 'src/main'
+          level: error
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        if: always()
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      # Discord に通知を送信するためのアクション
+      - name: Discord Notification
+          uses: sarisia/actions-status-discord@v1
+          if: always()
+          with:
+            webhook: ${{ secrets.DISCORD_WEBHOOK }}
+            status: ${{ job.status }}
+            title: "Checkstyle"
+            description: "Run Checkstyle"
+            color: "#cb88d2"
+            url: "https://github.com/sarisia/actions-status-discord"
+            username: GitHub Actions
+

--- a/.gradle/workflows/MovieInformationTest.yml
+++ b/.gradle/workflows/MovieInformationTest.yml
@@ -57,14 +57,14 @@ jobs:
 
       # Discord に通知を送信するためのアクション
       - name: Discord Notification
-          uses: sarisia/actions-status-discord@v1
+          uses: "sarisia/actions-status-discord@v1"
           if: always()
           with:
             webhook: ${{ secrets.DISCORD_WEBHOOK }}
             status: ${{ job.status }}
-            title: "Checkstyle"
-            description: "Run Checkstyle"
-            color: "#cb88d2"
+            title: "Continuous Integration"　
+            description: "Run Continuous Integration"
+            color: "#88d297"
             url: "https://github.com/sarisia/actions-status-discord"
             username: GitHub Actions
 

--- a/.gradle/workflows/MovieInformationTest.yml
+++ b/.gradle/workflows/MovieInformationTest.yml
@@ -3,7 +3,6 @@ name: movieInformation-CI
 #プルリクエスト実行時にワークフローが作動
 on:
   push:
-    branches: [ main ]
   pull_request:
 
 #コンテンツの読み取りとチェックの書き込み権限が指定

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.5'
     id 'io.spring.dependency-management' version '1.1.3'
+    id 'checkstyle'
 }
 
 group = 'movie.information'
@@ -29,4 +30,8 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+checkstyle {
+    toolVersion = '10.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.1.5'
     id 'io.spring.dependency-management' version '1.1.3'
     id 'checkstyle'
+    id 'jacoco'
 }
 
 group = 'movie.information'
@@ -30,8 +31,17 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
 
 checkstyle {
     toolVersion = '10.2'
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = false
+    }
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,366 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.org (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="warning"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Excludes all 'module-info.java' files              -->
+    <!-- See https://checkstyle.org/config_filefilters.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+    <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+                  default="checkstyle-suppressions.xml"/>
+        <property name="optional" value="true"/>
+    </module>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.org/config_whitespace.html -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+        <property name="max" value="100"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
+    <module name="TreeWalker">
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format"
+                      value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message"
+                      value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap">
+            <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+        </module>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens"
+                      value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces">
+            <property name="tokens"
+                      value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+        </module>
+        <module name="LeftCurly">
+            <property name="tokens"
+                      value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlySame"/>
+            <property name="tokens"
+                      value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAlone"/>
+            <property name="option" value="alone"/>
+            <property name="tokens"
+                      value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF"/>
+        </module>
+        <module name="SuppressionXpathSingleFilter">
+            <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+            <property name="id" value="RightCurlyAlone"/>
+            <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
+                                     or preceding-sibling::*[last()][self::LCURLY]]"/>
+        </module>
+        <module name="WhitespaceAfter">
+            <property name="tokens"
+                      value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_RETURN,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, DO_WHILE, ELLIPSIS,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_CATCH, LAMBDA"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyLambdas" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <property name="ignoreEnhancedForColon" value="false"/>
+            <property name="tokens"
+                      value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                    LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
+            <message key="ws.notFollowed"
+                     value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+            <message key="ws.notPreceded"
+                     value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="tokens"
+                      value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF"/>
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapDot"/>
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapComma"/>
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/259 -->
+            <property name="id" value="SeparatorWrapEllipsis"/>
+            <property name="tokens" value="ELLIPSIS"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/258 -->
+            <property name="id" value="SeparatorWrapArrayDeclarator"/>
+            <property name="tokens" value="ARRAY_DECLARATOR"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapMethodRef"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+                     value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    ANNOTATION_DEF, RECORD_DEF"/>
+            <message key="name.invalidPattern"
+                     value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+                     value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LambdaParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="PatternVariableName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="RecordComponentName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Record component name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="RecordTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Record type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+                     value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+            <message key="ws.preceded"
+                     value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+            <message key="ws.illegalFollow"
+                     value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="4"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="4"/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="0"/>
+            <property name="tokens"
+                      value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
+                    RECORD_COMPONENT_DEF"/>
+        </module>
+        <module name="NoWhitespaceBeforeCaseDefaultColon"/>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <!--
+        <module name="CustomImportOrder">
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+            <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
+        </module>-->
+        <module name="MethodParamPad">
+            <property name="tokens"
+                      value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF"/>
+        </module>
+        <module name="NoWhitespaceBefore">
+            <property name="tokens"
+                      value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+                    LABELED_STAT, METHOD_REF"/>
+            <property name="allowLineBreaks" value="true"/>
+        </module>
+        <module name="ParenPad">
+            <property name="tokens"
+                      value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
+                    RECORD_DEF"/>
+        </module>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens"
+                      value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF,
+                    TYPE_EXTENSION_AND "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationMostCases"/>
+            <property name="tokens"
+                      value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+                      RECORD_DEF, COMPACT_CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationVariables"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="InvalidJavadocPosition"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="SummaryJavadoc">
+            <property name="forbiddenSummaryFragments"
+                      value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        </module>
+        <module name="JavadocParagraph"/>
+        <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target"
+                      value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="accessModifiers" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
+        </module>
+        <!--        <module name="MissingJavadocMethod">-->
+        <!--            <property name="scope" value="public"/>-->
+        <!--            <property name="minLineCount" value="2"/>-->
+        <!--            <property name="allowedAnnotations" value="Override, Test"/>-->
+        <!--            <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,-->
+        <!--                                           COMPACT_CTOR_DEF"/>-->
+        <!--        </module>-->
+        <!--        <module name="MissingJavadocType">-->
+        <!--            <property name="scope" value="protected"/>-->
+        <!--            <property name="tokens"-->
+        <!--                      value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,-->
+        <!--                              RECORD_DEF, ANNOTATION_DEF"/>-->
+        <!--            <property name="excludeScope" value="nothing"/>-->
+        <!--        </module>-->
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+                     value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc"/>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation">
+            <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
+        </module>
+        <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+                      default="checkstyle-xpath-suppressions.xml"/>
+            <property name="optional" value="true"/>
+        </module>
+    </module>
+</module>

--- a/src/test/java/movie/information/MovieInformation/MovieInformationApplicationTests.java
+++ b/src/test/java/movie/information/MovieInformation/MovieInformationApplicationTests.java
@@ -1,9 +1,10 @@
 package movie.information.MovieInformation;
 
+import movieinformation.MovieInformationApplication;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes= MovieInformationApplication.class)
 class MovieInformationApplicationTests {
 
 	@Test

--- a/src/test/java/movieinformation/service/MovieInformationServiceTest.java
+++ b/src/test/java/movieinformation/service/MovieInformationServiceTest.java
@@ -76,19 +76,19 @@ class MovieInformationServiceTest {
     //POSTのテストコード
     @Test
     public void 存在しない映画情報を新規登録すること() {
-        Movie movie = new Movie("Marvel's The Avengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988);
+        Movie movie = new Movie("Marvel'sTheAvengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988);
         doNothing().when(movieInformationMapper).insert(movie);
         Movie actual = movieInformationService.insert(movie);
-        assertThat(actual).isEqualTo(new Movie("Marvel's The Avengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988));
+        assertThat(actual).isEqualTo(new Movie("Marvel'sTheAvengers", LocalDate.of(2012, 8, 14), "Joseph Hill Whedon", 1518812988));
         verify(movieInformationMapper, times(1)).findByName(movie.getName());
         verify(movieInformationMapper, times(1)).insert(movie);
     }
 
     @Test
     public void 存在する映画情報を新規登録する場合に重複登録の例外処理が動作すること() throws MovieDuplicationException {
-        Movie movie = new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007);
+        Movie movie = new Movie("EpisodeIV–ANewHope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007);
         doReturn(Optional.of(movie.getName())).when(movieInformationMapper).findByName(movie.getName());
-        assertThrows(MovieDuplicationException.class, () -> movieInformationService.insert(new Movie("Episode IV – A New Hope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007)));
+        assertThrows(MovieDuplicationException.class, () -> movieInformationService.insert(new Movie("EpisodeIV–ANewHope", LocalDate.of(1978, 6, 30), "George Walton Lucas Jr.", 775398007)));
         verify(movieInformationMapper, times(1)).findByName(movie.getName());
         verify(movieInformationMapper, times(0)).insert(movie);
     }


### PR DESCRIPTION
## 概要
GitHub ActionsのCIとCodecovを追加実装しました。
プルリクエスト時に動作するように設定しています。
また都度、Discordにも通知が届くように設定しました。

## 動作確認
### GitHub ActionsのCI
プルリクエストした際に動作することが確認できました。
テストのフィードバックも確認できています。
今回の場合、16個のテスト全てが通っていることが確認できました。
<img width="1236" alt="スクリーンショット 2023-11-12 15 16 14" src="https://github.com/yamahiro20639/Movie-Information-Management-API/assets/144509349/9a44f2ba-e63a-4d30-a7d0-4efce5258c07">

### Codecov
こちらもプルリクエスト時に動作することが確認できました。
カバレッジ率のレポートも確認しました。
<img width="1680" alt="スクリーンショット 2023-11-12 15 18 40" src="https://github.com/yamahiro20639/Movie-Information-Management-API/assets/144509349/c31c5cef-3239-487e-b4ae-04e4f73d60ab">
<img width="700" alt="スクリーンショット 2023-11-12 15 37 59" src="https://github.com/yamahiro20639/Movie-Information-Management-API/assets/144509349/baf45b04-2dd7-4b34-8f47-306473be9cef">

## Discordへの通知
プルリクエスト時やCIのチェックが完了した際にDiscordに通知が届くことが確認できました。
<img width="1608" alt="スクリーンショット 2023-11-12 15 42 10" src="https://github.com/yamahiro20639/Movie-Information-Management-API/assets/144509349/deb6ac7d-1a5c-4745-be7d-516db0903372">
