### PR TITLE
DBのDelete機能に対してテストコード実装

### DIFF
--- a/src/test/java/movieinformation/mapper/MovieInformationMapperTest.java
+++ b/src/test/java/movieinformation/mapper/MovieInformationMapperTest.java
@@ -118,4 +118,12 @@ class MovieInformationMapperTest {
         movieInformationMapper.delete(1);
     }
 
+    @Test
+    @DataSet(value ="datasets/movieData.yml")
+    @ExpectedDataSet(value ="datasets/movieData.yml")
+    @Transactional
+    public void 存在しない映画情報を削除した場合はテーブルの既存レコードは削除されないこと(){
+        movieInformationMapper.delete(100);
+    }
+
 }

--- a/src/test/java/movieinformation/mapper/MovieInformationMapperTest.java
+++ b/src/test/java/movieinformation/mapper/MovieInformationMapperTest.java
@@ -109,4 +109,13 @@ class MovieInformationMapperTest {
         Movie movie = new Movie(1, "Rogue One: A Star Wars Story", LocalDate.of(2016, 12, 16), "Gareth Edwards", 1056057273);
         movieInformationMapper.update(movie);
     }
+    //DELETE機能のDBテスト
+    @Test
+    @DataSet(value ="datasets/movieData.yml")
+    @ExpectedDataSet(value = "datasets/delete_movieData.yml")
+    @Transactional
+    public void 存在する映画情報を削除すること(){
+        movieInformationMapper.delete(1);
+    }
+
 }


### PR DESCRIPTION
## 概要
DBのDelete機能に対してテストコードを実装しました。
テストは下記２種類になります。

①存在する映画情報を削除すること
578ae4210903e443029fba44b9aac932b8c1963f

②存在しない映画情報を削除した場合はテーブルの既存レコードは削除されないこと
8bbdb278737d58ae70347a680f0ec8a646c5a329

## 動作確認
２種類ともテストをパスしました。
CI上のテストにもパスしています。

①存在する映画情報を削除すること
<img width="1680" alt="スクリーンショット 2023-11-13 8 45 46" src="https://github.com/yamahiro20639/Movie-Information-Management-API/assets/144509349/c500c599-d170-44c1-a1e4-4414c4aa89d8">

②存在しない映画情報を削除した場合はテーブルの既存レコードは削除されないこと
<img width="1680" alt="スクリーンショット 2023-11-13 8 57 02" src="https://github.com/yamahiro20639/Movie-Information-Management-API/assets/144509349/5bd17ab1-0778-44f7-96ab-c9da20a154d6">
