### PR TITLE
Read機能の結合テスト追加実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,19 @@ IDで指定した映画(26,27,28番)が削除される事を確認。<br>
 </details>
 
 ***
+## テストコードの実装
+下記テストコードを実装しました。またGitHub Actionsを用いて自動化しました。<br>
+ * <font size="4"> 単体テスト </font> <br>
+   
+   * <font size="3"> MovieInformationServiceTest</font> 
+   * <font size="3"> MovieInformationMapperTest </font>
+ * <font size="4"> 結合テスト </font> <br>
+   
+   * <font size="3">  MovieInformationRestApiIntegrationTest </font>
+
+## Codecovの実装
+
+***
 ## 振り返り
 今回、初めてのアプリケーション開発を通して、Java言語の知識だけではなく、フレームワークやデータベース、テストなど様々な知識を学ぶことができました。<br>
 

--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -13,7 +13,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.nio.charset.StandardCharsets;
 
 @SpringBootTest
@@ -28,7 +27,7 @@ import java.nio.charset.StandardCharsets;
     @Test
     @DataSet(value = "datasets/movieData.yml")
     @Transactional
-    public void 映画情報をステータスコード200で全件取得すること() throws Exception{
+    public void 映画情報をステータスコード200で全件取得すること() throws Exception {
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/movies"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
@@ -56,7 +55,37 @@ import java.nio.charset.StandardCharsets;
                    "boxOffice": 868390560
                  }
                 ]
-                 """,response, JSONCompareMode.STRICT);
+                 """, response, JSONCompareMode.STRICT);
     }
 
+    @Test
+    @DataSet(value = "datasets/movieData.yml")
+    @Transactional
+    public void 存在する映画をID指定して情報とステータスコード200を取得すること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/movies/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+           
+                 {
+                   "id": 1,
+                   "name": "Episode I – The Phantom Menace",
+                   "releaseDate": "1999-07-10",
+                   "directorName": "George Walton Lucas Jr.",
+                   "boxOffice": 1027082707
+                 }
+                
+                 """, response, JSONCompareMode.STRICT);
+    }
+    @Test
+    @DataSet(value = "datasets/movieData.yml")
+    @Transactional
+    public void 存在しないIDを指定するとステータスコード404とエラーメッセージを取得すること()throws Exception{
+   mockMvc.perform(MockMvcRequestBuilders.get("/movies/100"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getErrorMessage();
+    }
 }
+
+
+

--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -86,6 +86,3 @@ import java.nio.charset.StandardCharsets;
                 .andReturn().getResponse().getErrorMessage();
     }
 }
-
-
-


### PR DESCRIPTION
## 概要
91038b70dad5ec0edba7a55c771ac5b53bc514aa
Read機能の結合テストについて追加実装しました。
実装内容は下記2点になります。

・存在する映画をID(1番)指定して情報とステータスコード200を取得すること
・存在しないID(100番)を指定するとステータスコード404とエラーメッセージを取得すること

## 動作確認
CI上での結合テストでも問題なく通りました。
Read機能が適切に動作できることが確認できています。