### PR TITLE
Integration test/create

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ IDで指定した映画(26,27,28番)が削除される事を確認。<br>
    * <font size="3">  MovieInformationRestApiIntegrationTest </font>
 
 ## Codecovの実装
+アプリケーションが適切にかつ網羅的にテストできるように、Codecovを実装しました。
 
 ***
 ## 振り返り

--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -105,4 +105,17 @@ import java.time.LocalDate;
         mockMvc.perform(MockMvcRequestBuilders.post("/movies").contentType(MediaType.APPLICATION_JSON).content(jason))
                 .andExpect(MockMvcResultMatchers.status().isCreated());
     }
+
+    @Test
+    @DataSet(value ="datasets/movieData.yml")
+    @Transactional
+    public void 重複登録の場合はステータスコード400とエラーメッセージが返ってくる()throws Exception{
+        Movie movie = new Movie("Episode I – The Phantom Menace", LocalDate.of(1999,7,10),"George Walton Lucas Jr.",1027082707);
+        ObjectMapper mapper= new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        String jason = mapper.writeValueAsString(movie);
+        mockMvc.perform(MockMvcRequestBuilders.post("/movies").contentType(MediaType.APPLICATION_JSON).content(jason))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andReturn().getResponse().getErrorMessage();
+    }
 }

--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -97,7 +97,7 @@ import java.time.LocalDate;
     @DataSet(value ="datasets/movieData.yml")
     @ExpectedDataSet(value ="datasets/insert_movieData.yml", ignoreCols = "id")
     @Transactional
-    public void 新規の映画がDBに登録される事とステータスコード201が返ってくる事()throws Exception{
+    public void 新規の映画がDBに登録されるとステータスコード201が返ってくる事()throws Exception{
         Movie movie = new Movie("Episode VII – The Force Awakens", LocalDate.of(2015,12,18),"Jeffrey Jacob Abrams",2071310218);
         ObjectMapper mapper= new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
@@ -114,7 +114,13 @@ import java.time.LocalDate;
         ObjectMapper mapper= new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
         String jason = mapper.writeValueAsString(movie);
-        mockMvc.perform(MockMvcRequestBuilders.post("/movies").contentType(MediaType.APPLICATION_JSON).content(jason))
+        mockMvc.perform(MockMvcRequestBuilders.post("/movies").contentType(MediaType.APPLICATION_JSON).content(jason).content("""
+           
+                 {
+                   "message":"Already registered data"
+                 }
+                
+                 """))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andReturn().getResponse().getErrorMessage();
     }

--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -1,5 +1,7 @@
 package movieinformation.integrationtest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
@@ -11,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -92,10 +95,14 @@ import java.time.LocalDate;
     //Create機能のIntegrationTest
     @Test
     @DataSet(value ="datasets/movieData.yml")
-    @ExpectedDataSet(value ="datasets/insert_movieData.yml")
+    @ExpectedDataSet(value ="datasets/insert_movieData.yml", ignoreCols = "id")
     @Transactional
     public void 新規の映画がDBに登録される事とステータスコード201が返ってくる事()throws Exception{
-        //Movie movie = new Movie("Episode VII – The Force Awakens", LocalDate.of(2015,12,18),"Jeffrey Jacob Abrams",2071310218);
-        mockMvc.perform(MockMvcRequestBuilders.post("/movies")).andExpect(MockMvcResultMatchers.status().isCreated());
+        Movie movie = new Movie("Episode VII – The Force Awakens", LocalDate.of(2015,12,18),"Jeffrey Jacob Abrams",2071310218);
+        ObjectMapper mapper= new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        String jason = mapper.writeValueAsString(movie);
+        mockMvc.perform(MockMvcRequestBuilders.post("/movies").contentType(MediaType.APPLICATION_JSON).content(jason))
+                .andExpect(MockMvcResultMatchers.status().isCreated());
     }
 }

--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -1,7 +1,9 @@
 package movieinformation.integrationtest;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
+import movieinformation.entity.Movie;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -84,5 +86,15 @@ import java.nio.charset.StandardCharsets;
    mockMvc.perform(MockMvcRequestBuilders.get("/movies/100"))
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andReturn().getResponse().getErrorMessage();
+    }
+
+    //Create機能のIntegrationTest
+    @Test
+    @DataSet(value ="datasets/movieData.yml")
+    @ExpectedDataSet(value ="datasets/movieData.yml")
+    @Transactional
+    public void 新規の映画がDBに登録される事とステータスコード201が返ってくる事(){
+        Movie movie = new Movie()
+        mockMvc.perform(MockMvcRequestBuilders.post()
     }
 }

--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -91,10 +92,10 @@ import java.nio.charset.StandardCharsets;
     //Create機能のIntegrationTest
     @Test
     @DataSet(value ="datasets/movieData.yml")
-    @ExpectedDataSet(value ="datasets/movieData.yml")
+    @ExpectedDataSet(value ="datasets/insert_movieData.yml")
     @Transactional
     public void 新規の映画がDBに登録される事とステータスコード201が返ってくる事(){
-        Movie movie = new Movie()
-        mockMvc.perform(MockMvcRequestBuilders.post()
+        Movie movie = new Movie("Episode VII – The Force Awakens", LocalDate.of(2015,12,18),"Jeffrey Jacob Abrams",2071310218);
+        mockMvc.perform(MockMvcRequestBuilders.post(String.valueOf(movie))
     }
 }

--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -114,14 +114,8 @@ import java.time.LocalDate;
         ObjectMapper mapper= new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
         String jason = mapper.writeValueAsString(movie);
-        mockMvc.perform(MockMvcRequestBuilders.post("/movies").contentType(MediaType.APPLICATION_JSON).content(jason).content("""
-           
-                 {
-                   "message":"Already registered data"
-                 }
-                
-                 """))
+        mockMvc.perform(MockMvcRequestBuilders.post("/movies").contentType(MediaType.APPLICATION_JSON).content(jason))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
-                .andReturn().getResponse().getErrorMessage();
+                .andReturn().getResponse().getContentAsString().contains("Already registered data");
     }
 }

--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -94,8 +94,8 @@ import java.time.LocalDate;
     @DataSet(value ="datasets/movieData.yml")
     @ExpectedDataSet(value ="datasets/insert_movieData.yml")
     @Transactional
-    public void 新規の映画がDBに登録される事とステータスコード201が返ってくる事(){
-        Movie movie = new Movie("Episode VII – The Force Awakens", LocalDate.of(2015,12,18),"Jeffrey Jacob Abrams",2071310218);
-        mockMvc.perform(MockMvcRequestBuilders.post(String.valueOf(movie))
+    public void 新規の映画がDBに登録される事とステータスコード201が返ってくる事()throws Exception{
+        //Movie movie = new Movie("Episode VII – The Force Awakens", LocalDate.of(2015,12,18),"Jeffrey Jacob Abrams",2071310218);
+        mockMvc.perform(MockMvcRequestBuilders.post("/movies")).andExpect(MockMvcResultMatchers.status().isCreated());
     }
 }

--- a/src/test/resources/datasets/insert_movieData.yml
+++ b/src/test/resources/datasets/insert_movieData.yml
@@ -4,20 +4,16 @@ movie_list:
     release_date: '1999-07-10'
     director_name: 'George Walton Lucas Jr.'
     box_office: 1027082707
-
   - id: 2
     name: 'Episode II – Attack of the Clones'
     release_date: '2002-05-16'
     director_name: 'George Walton Lucas Jr.'
     box_office: 653779970
-
-
   - id: 3
     name: 'Episode III – Revenge of the Sith'
     release_date: '2005-07-09'
     director_name: 'George Walton Lucas Jr.'
     box_office: 868390560
-
   - id: 4
     name: 'Episode VII – The Force Awakens'
     release_date: '2015-12-18'


### PR DESCRIPTION
## 概要
Create機能で下記２種類の結合テストを実施しました。
①新規の映画が登録されるとステータスコード201が返ってくる事
e1cc986974b3cf0bb7f20a0d8982ababc95e2e61
②重複登録の場合はステータスコード400とエラーメッセージが返ってくる
2d2d40927d172ba7ab567761276e27daab9b926b

## 結果
CIの結果からも適切にCreate機能が作動していることが確認できた。
<img width="1592" alt="スクリーンショット 2023-12-24 18 37 48" src="https://github.com/yamahiro20639/Movie-Information-Management-API/assets/144509349/63c1d487-484e-4420-b4e2-a4527bbeaa17">

