### PR TITLE
Update機能の結合テストを実装

### DIFF
--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -156,7 +156,16 @@ import java.time.LocalDate;
     @DataSet(value ="datasets/movieData.yml")
     @Transactional
     public void 存在しない映画情報を更新処理するとステータスコード404とエラーメッセージを取得すること()throws Exception{
-        Assertions.assertTrue(mockMvc.perform(MockMvcRequestBuilders.patch("/movies/100"))
+        Assertions.assertTrue(mockMvc.perform(MockMvcRequestBuilders.patch("/movies/100")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+            {
+              "name": "Rogue One: A Star Wars Story",
+              "releaseDate": "2016-12-16",
+              "directorName": "Gareth Edwards",
+              "boxOffice": 1056057273
+            }
+            """))
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andReturn().getResponse().getContentAsString().contains("Movie not found"));
     }


### PR DESCRIPTION
## 概要
Update機能で下記２種類の結合テストを実施しました。
①存在する映画情報を更新するとステータスコード200と指定のメッセージを取得することや正しく更新されているか確認すること
c81e6e25491b69e105faf5dc42bb1fbc515495e3

②存在しない映画情報を更新処理するとステータスコード404とエラーメッセージを取得すること
f0bb42804a12aa1b0975db42dafe88dcffe26968

## 結果
CIの結果からも適切にUpdate機能が作動していることが確認できました。
<img width="878" alt="スクリーンショット 2024-01-01 12 55 55" src="https://github.com/yamahiro20639/Movie-Information-Management-API/assets/144509349/d4fed6fa-b4dd-4f80-b66e-01944f4a17dc">
