### PR TITLE
delete機能の結合テストを実装

### DIFF
--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -169,5 +169,44 @@ import java.time.LocalDate;
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andReturn().getResponse().getContentAsString().contains("Movie not found"));
     }
+    //Delete機能のIntegrationTest
+    @Test
+    @DataSet(value = "datasets/movieData.yml")
+    @ExpectedDataSet(value ="datasets/delete_movieData.yml")
+    @Transactional
+    public void 存在する映画情報を削除するとステータスコード200と指定のメッセージを取得することや正しく削除されているか確認すること()throws Exception{
+        Assertions.assertTrue(mockMvc.perform(MockMvcRequestBuilders.delete("/movies/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString().contains("Movie deleted"));
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/movies"))
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+         [
+         {
+           "id": 2,
+           "name": "Episode II – Attack of the Clones",
+           "releaseDate": "2002-05-16",
+           "directorName": "George Walton Lucas Jr.",
+           "boxOffice": 653779970
+         },
+         {
+           "id": 3,
+           "name": "Episode III – Revenge of the Sith",
+           "releaseDate": "2005-07-09",
+           "directorName": "George Walton Lucas Jr.",
+           "boxOffice": 868390560
+         }
+         ]
+         """, response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value ="datasets/movieData.yml")
+    @Transactional
+    public void 存在しない映画情報を削除処理するとステータスコード404とエラーメッセージを取得すること()throws Exception{
+        Assertions.assertTrue(mockMvc.perform(MockMvcRequestBuilders.delete("/movies/100"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString().contains("Movie not found"));
+    }
 
 }

--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
@@ -203,10 +204,37 @@ import java.time.LocalDate;
     @Test
     @DataSet(value ="datasets/movieData.yml")
     @Transactional
-    public void 存在しない映画情報を削除処理するとステータスコード404とエラーメッセージを取得すること()throws Exception{
+    public void 存在しない映画情報を削除処理するとステータスコード404とエラーメッセージを取得すること()throws Exception {
         Assertions.assertTrue(mockMvc.perform(MockMvcRequestBuilders.delete("/movies/100"))
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andReturn().getResponse().getContentAsString().contains("Movie not found"));
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/movies"))
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+                [
+                 {
+                   "id": 1,
+                   "name": "Episode I – The Phantom Menace",
+                   "releaseDate": "1999-07-10",
+                   "directorName": "George Walton Lucas Jr.",
+                   "boxOffice": 1027082707
+                 },
+                 {
+                   "id": 2,
+                   "name": "Episode II – Attack of the Clones",
+                   "releaseDate": "2002-05-16",
+                   "directorName": "George Walton Lucas Jr.",
+                   "boxOffice": 653779970
+                 },
+                 {
+                   "id": 3,
+                   "name": "Episode III – Revenge of the Sith",
+                   "releaseDate": "2005-07-09",
+                   "directorName": "George Walton Lucas Jr.",
+                   "boxOffice": 868390560
+                 }
+                ]
+                 """, response, JSONCompareMode.STRICT);
     }
 
 }

--- a/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
+++ b/src/test/java/movieinformation/integrationtest/MovieInformationRestApiIntegrationTest.java
@@ -204,7 +204,7 @@ import java.time.LocalDate;
     @Test
     @DataSet(value ="datasets/movieData.yml")
     @Transactional
-    public void 存在しない映画情報を削除処理するとステータスコード404とエラーメッセージを取得すること()throws Exception {
+    public void 存在しない映画情報を削除処理するとステータスコード404とエラーメッセージを取得と削除されていないと確認すること()throws Exception {
         Assertions.assertTrue(mockMvc.perform(MockMvcRequestBuilders.delete("/movies/100"))
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andReturn().getResponse().getContentAsString().contains("Movie not found"));


### PR DESCRIPTION
# 概要
Delete機能で下記２種類の結合テストを実施しました。
①存在する映画情報を削除するとステータスコード200と指定のメッセージを取得すること、また正しく削除されているか確認すること
6d6a5eddd59724a36a674d36671d4f19033bfbfd

②存在しない映画情報を削除処理するとステータスコード404とエラーメッセージを取得と削除されていないと確認すること
107eebf21b92cdb20090f6975902f1a94f7b00ab

## 結果
CIの結果からも適切にCreate機能が作動していることが確認できた。
<img width="901" alt="スクリーンショット 2024-01-03 15 41 40" src="https://github.com/yamahiro20639/Movie-Information-Management-API/assets/144509349/aeaf1976-8f20-43e9-a29b-925dd14fd81e">
